### PR TITLE
generate JDBC url

### DIFF
--- a/functions
+++ b/functions
@@ -148,3 +148,10 @@ service_url() {
   local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
   echo "$PLUGIN_SCHEME://$SERVICE:$PASSWORD@$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}"
 }
+
+jdbc_url() {
+  local SERVICE="$1"
+  local PASSWORD="$(service_password "$SERVICE")"
+  local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
+  echo "jdbc:$PLUGIN_SCHEME://$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}/?user=$SERVICE&password=$PASSWORD"
+}


### PR DESCRIPTION
added function for generating the JDBC config URL.

I've been looking into the various link-related functions... But I think adding a second 'dedicated' command for just injecting the JDBC URL into the config for an app (link-via-jdbc o.i.d. or just a `get-jdbc-url`) makes more sense. That could expose the url and leave it up to the user to configure the JDBC enabled app (java or otherwise) 

What do you think?

#94